### PR TITLE
Force encoding of the context for the response of an SSI include

### DIFF
--- a/lib/ssi_processor.rb
+++ b/lib/ssi_processor.rb
@@ -32,7 +32,7 @@ module Rack
         if stub && (status != 200 || body.nil? || body == "")
           blocks[stub] 
         else
-          body
+          body.force_encoding(part.encoding)
         end
       end
     end


### PR DESCRIPTION
We use SSI to insert frequently changing text parts on our side (e.g. price changes).
At the moment we have a .txt file on CloudFront with the content "€254".

When I try to include that file I get the error:
incompatible character encodings: UTF-8 and ASCII-8BIT

Traceback:
rack_ssi (0.0.2) lib/ssi_processor.rb:28:in `gsub'
rack_ssi (0.0.2) lib/ssi_processor.rb:28:in`process_include'
rack_ssi (0.0.2) lib/ssi_processor.rb:13:in `block in process'
...

The ngnix SSI implementation works fine.

My solution is to force the encoding of the context for the response of an SSI include.

Cheers,
Thomas
